### PR TITLE
add extra user-agent option

### DIFF
--- a/survata-sdk/src/main/java/com/survata/utils/Utils.java
+++ b/survata-sdk/src/main/java/com/survata/utils/Utils.java
@@ -1,6 +1,7 @@
 package com.survata.utils;
 
 import android.content.Context;
+import android.content.res.Resources;
 import android.os.AsyncTask;
 import android.text.TextUtils;
 import android.util.Base64;
@@ -90,14 +91,22 @@ public class Utils {
     public static String getUserAgent(Context context) {
         String packageName = "Unknown";
         String versionName = "Unknown";
+        String resourceName = "Unknown";
+
         try {
             packageName = context.getPackageName();
             versionName = context.getPackageManager().getPackageInfo(packageName, 0).versionName;
+
+            Resources res = context.getResources();
+            int resId = res.getIdentifier("app_name", "string", packageName);
+            resourceName = res.getString(resId);
+
         } catch (Exception e) {
             Logger.e(TAG, "get user agent failed", e);
         }
 
-        String currentUserAgent = context.getString(R.string.app_name) + "/" + packageName;
+        String currentUserAgent = resourceName + "/" + packageName;
+
         return String.format(USER_AGENT, currentUserAgent, versionName);
     }
 


### PR DESCRIPTION
I'm not quite sure how to test what sort of exceptions it comes across if the 1st attempt doesn't work. so I had it just catch all exceptions and then do the second attempt in the nested try catch. 
I know pretty shitty...

If you have any better ideas, or on how to test it, please tell. 🙏 

THis is the email

```
During testing we had this exception: https://gist.github.com/anonymous/a0ddde564379fe75437b0df7ecc9576a . Thanks to AndroidStudio's feature to look inside jar file, I found that "com.survata.utils.Utils.getUserAgent(Utils.java:100)" loads app's name via com.survata.R.string class. Could you change this:

String currentUserAgent = context.getString(string.app_name) + "/" + packageName;

to:

Resources res = context.getResources();
int resId = res.getIdentifier("app_name", "string", context.getPackageName());
String currentUserAgent = res.getString(resId) + "/" + packageName;

?

In case when you can't receive package name you can, use some static text for userAgent.
```

